### PR TITLE
Remove cleanup code from nativeOnFinalize for now and keep the same D…

### DIFF
--- a/daliview/src/main/cpp/daliview.cpp
+++ b/daliview/src/main/cpp/daliview.cpp
@@ -272,25 +272,7 @@ extern "C" JNIEXPORT void JNICALL Java_com_sec_daliview_DaliView_nativeOnKeyEven
 extern "C" JNIEXPORT void JNICALL Java_com_sec_daliview_DaliView_nativeOnFinalize(JNIEnv* jenv, jobject obj, jlong handle)
 {
   DALI_LOG_RELEASE_INFO( "nativeOnFinalize handle(%lld)", handle );
-
-  if( handle )
-  {
-    AConfiguration* configuration = Dali::Integration::AndroidFramework::Get().GetApplicationConfiguration();
-    Dali::Integration::AndroidFramework::Get().OnTerminate();
-
-    if( configuration )
-    {
-      AConfiguration_delete( configuration );
-      Dali::Integration::AndroidFramework::Get().SetApplicationConfiguration( nullptr );
-    }
-
-    Dali::Integration::AndroidFramework::Get().SetApplicationAssets( nullptr );
-
-    Dali::RefObject* refObject = reinterpret_cast<Dali::RefObject*>( handle );
-    refObject->Unreference();
-
-    Dali::Integration::AndroidFramework::Delete();
-  }
+  // We don't have an option to cleanup existing DALi instance yet - needs major refactoring in DALi
 }
 
 extern "C" JNIEXPORT jboolean JNICALL Java_com_sec_daliview_DaliView_nativeOnCallback(JNIEnv* jenv, jclass clazz, jlong callback, jlong callbackData)

--- a/daliview/src/main/java/com/sec/daliview/DaliView.java
+++ b/daliview/src/main/java/com/sec/daliview/DaliView.java
@@ -95,7 +95,9 @@ public class DaliView extends SurfaceView implements SurfaceHolder.Callback {
     protected void finalize() throws Throwable {
         try {
             nativeOnFinalize(nativeHandle);
-            nativeHandle = 0;
+            // nativeHandle = 0;
+            // Keep the same instance of DALi for now until DALi cleanup is sorted.
+            // The application will be restarted by the system eventually.
         } finally {
             super.finalize();
         }


### PR DESCRIPTION
We don't have an option to cleanup existing DALi instance yet - needs major refactoring in DALi.
For now we keep the same instance until the system decides to restart the application.